### PR TITLE
Support separate FWaaS tests for terraform-openstack-provider

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -254,6 +254,30 @@
       mysql:
 
 - pipeline:
+    name: recheck-fwaas
+    description: |
+      Commenting "recheck fwaas" enter this pipeline to run fwaas tests
+      on master of OpenStack and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s+fwaas\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
     name: check-orange
     post-review: true
     description: |


### PR DESCRIPTION
Define separate pipeline for FWaaS tests

Fixes: https://github.com/theopenlab/openlab-zuul-jobs/issues/35

Part of https://github.com/orgs/theopenlab/projects/1#card-6800912