### PR TITLE
Change to use generic pipeline to trigger different cloud jobs

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -152,36 +152,6 @@
     trigger: {}
 
 - pipeline:
-    name: check-telefonica
-    post-review: true
-    description: |
-      Commenting "recheck telefonica" enter this pipeline to run tests on
-      telefonica cloud and receive an initial +/-1 Verified vote.
-    manager: independent
-    trigger:
-      github:
-#        - event: pull_request
-#          action:
-#            - opened
-#            - changed
-#            - reopened
-        - event: pull_request
-          action: comment
-          comment: (?i)^\s*recheck\s+telefonica\s*$
-    start:
-      github:
-        status: pending
-        comment: false
-    success:
-      github:
-        status: 'success'
-      mysql:
-    failure:
-      github:
-        status: 'failure'
-      mysql:
-
-- pipeline:
     name: recheck-designate
     description: |
       Commenting "recheck designate" enter this pipeline to run designate tests
@@ -264,36 +234,6 @@
         - event: pull_request
           action: comment
           comment: (?i)^\s*recheck\s+fwaas\s*$
-    start:
-      github:
-        status: pending
-        comment: false
-    success:
-      github:
-        status: 'success'
-      mysql:
-    failure:
-      github:
-        status: 'failure'
-      mysql:
-
-- pipeline:
-    name: check-orange
-    post-review: true
-    description: |
-      Commenting "recheck orange" enter this pipeline to run tests on
-      orange cloud and receive an initial +/-1 Verified vote.
-    manager: independent
-    trigger:
-      github:
-#        - event: pull_request
-#          action:
-#            - opened
-#            - changed
-#            - reopened
-        - event: pull_request
-          action: comment
-          comment: (?i)^\s*recheck\s+orange\s*$
     start:
       github:
         status: pending


### PR DESCRIPTION
This change clean the old pipelines since we agree to swith to use a
generic pipeline to trigger jobs of different clouds.

Part of: #8