### PR TITLE
Avoid the potential security problem

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -128,7 +128,6 @@
 
 - pipeline:
     name: periodic
-    post-review: true
     description: Jobs in this queue are triggered on a timer.
     manager: independent
     precedence: low
@@ -249,7 +248,6 @@
 
 - pipeline:
     name: check-generic-cloud
-    post-review: true
     description: |
       Commenting "recheck" enter this pipeline to run tests against
       generic clouds and receive an initial +/-1 Verified vote.


### PR DESCRIPTION
The `post-review` option of pipeline may allow to expose the CI nodepools providers' credentials, this change fix that.