### PR TITLE
Add pipelines for K8S+OpenStack scenarios testing

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -269,3 +269,210 @@
       github:
         status: 'failure'
       mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-all
+    description: |
+      Commenting "/retest" or "/test all" enter this pipeline to run all the test jobs of
+      Kubernetes+OpenStack scenarios and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/retest\s*$
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test all\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-unit
+    description: |
+      Commenting "/test cloud-provider-openstack-unit" enter this pipeline to run
+      the unit tests of cloud-provider-openstack repo and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-unit\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-lb
+    description: |
+      Commenting "/test cloud-provider-openstack-lb" enter this pipeline to run
+      the test job of Kubernetes+OpenStack LBaaS scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-lb\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-auth
+    description: |
+      Commenting "/test cloud-provider-openstack-auth" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Keystone authentication/authorication
+      scenarios and receive an initial +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-auth\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-k8s-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-k8s-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack cinder scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-k8s-cinder\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-standalone-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-standalone-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder standalone scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-standalone-cinder\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-csi-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-csi-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder CSI scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-csi-cinder\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:
+
+- pipeline:
+    name: cloud-provider-openstack-flexvolume-cinder
+    description: |
+      Commenting "/test cloud-provider-openstack-flexvolume-cinder" enter this pipeline to run
+      the tests job of Kubernetes+OpenStack Cinder flexvolume scenarios and receive an initial
+      +/-1 Verified vote.
+    manager: independent
+    trigger:
+      github:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*\/test cloud-provider-openstack-csi-cinder\s*$
+    start:
+      github:
+        status: pending
+        comment: false
+    success:
+      github:
+        status: 'success'
+      mysql:
+    failure:
+      github:
+        status: 'failure'
+      mysql:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -463,7 +463,7 @@
       github:
         - event: pull_request
           action: comment
-          comment: (?i)^\s*\/test cloud-provider-openstack-csi-cinder\s*$
+          comment: (?i)^\s*\/test cloud-provider-openstack-flexvolume-cinder\s*$
     start:
       github:
         status: pending


### PR DESCRIPTION
- Add pipeline: cloud-provider-openstack-all
- Add pipeline: cloud-provider-openstack-unit
- Add pipeline: cloud-provider-openstack-lb
- Add pipeline: cloud-provider-openstack-auth
- Add pipeline: cloud-provider-openstack-k8s-cinder
- Add pipeline: cloud-provider-openstack-standalone-cinder
- Add pipeline: cloud-provider-openstack-csi-cinder
- Add pipeline: cloud-provider-openstack-flexvolume-cinder